### PR TITLE
update README to include readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # YTEP repository
 This repository hosts the text of yt enhancement proposals.
 
+You can see the rendered ytep documentation at:
+https://ytep.readthedocs.io
+
 If you would like to propose a new YTEP, fork this repository, 
 copy the text of the template YTEP into a new .rst file in the 
 YTEPs subfolder. Add the text of your YTEP, commit your changes, 


### PR DESCRIPTION
I noticed that we don't have any links to the rendered yteps on readthedocs in the source repo. I've added a link to our readme to make it more obvious where people can see the nicely formatted yteps.  